### PR TITLE
Add last commit to release comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         id: last-commit
         run : |
           cd src/wp-content/themes/
-          ( echo "LAST_UPSTREAM_COMMIT="; git log -1 -- twentyseventeen | grep -E '\(\#[0-9]+\)' ) >> $GITHUB_OUTPUT
+          ( echo "LAST_UPSTREAM_COMMIT=\""; git log -1 -- twentyseventeen | grep -E '\(\#[0-9]+\)'; echo "\""; ) >> $GITHUB_OUTPUT
           zip -r twentyseventeen.zip twentyseventeen 
           ls
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         id: last-commit
         run : |
           cd src/wp-content/themes/
-          ( echo "LAST_UPSTREAM_COMMIT=\""; git log -1 -- twentyseventeen | grep -E '\(\#[0-9]+\)'; echo "\""; ) >> $GITHUB_OUTPUT
+          ( echo -n "LAST_UPSTREAM_COMMIT=\""; git log -1 -- twentyseventeen | grep -E '\(\#[0-9]+\)' | tr -d '\n' ; echo "\""; ) >> $GITHUB_OUTPUT
           zip -r twentyseventeen.zip twentyseventeen 
           ls
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,28 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-      - name: Create artifact
+      - name: Create artifact and bring last commit
+        id: last-commit
         run : |
           cd src/wp-content/themes/
+          ( echo "LAST_UPSTREAM_COMMIT="; git log -1 -- twentyseventeen | grep -E '\(\#[0-9]+\)' ) >> $GITHUB_OUTPUT
           zip -r twentyseventeen.zip twentyseventeen 
           ls
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-            name: twentyseventeen
-            path: src/wp-content/themes/twentyseventeen.zip
+          name: twentyseventeen
+          path: src/wp-content/themes/twentyseventeen.zip
       - name: Upload to release
         uses: JasonEtco/upload-to-release@master
         with:
           args: src/wp-content/themes/twentyseventeen.zip application/zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload
+        uses: djn24/add-comment-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          comment: |-
+            Last commit:
+            ${{ steps.last-commit.outputs.LAST_UPSTREAM_COMMIT }}


### PR DESCRIPTION
Since this repo is only used for releases, so we can't see commits between tags, it's useful to keep track of the last commit to the theme.

If approved I'll do the same to:
- https://github.com/ClassicPress/the-classicpress-theme
- https://github.com/ClassicPress/cp-pepper


Screenshot, with last commit added.

<img width="1114" alt="Schermata 2025-07-08 alle 11 33 34" src="https://github.com/user-attachments/assets/93088c15-e638-4c09-bfe0-ee5a705f7841" />
